### PR TITLE
🩹 [Patch]: Handle empty hashtable in `Format-Hashtable` function

### DIFF
--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -65,6 +65,11 @@
         [int] $IndentLevel = 1
     )
 
+    # If the hashtable is empty, return '@{}' immediately.
+    if ($Hashtable -is [System.Collections.IDictionary] -and $Hashtable.Count -eq 0) {
+        return '@{}'
+    }
+
     $indent = '    '
     $lines = @()
     $lines += '@{'

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -270,11 +270,13 @@
                 $ht = [ordered]@{
                     Key1 = 'Value1'
                     Key2 = 123
+                    Key3 = @{}
                 }
                 $expected = @'
 @{
     Key1 = 'Value1'
     Key2 = 123
+    Key3 = @{}
 }
 '@.TrimEnd()
 

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -255,6 +255,16 @@
     }
 
     Describe 'Format-Hashtable' {
+        Context 'An empty hashtable' {
+            It 'returns an empty hashtable string' {
+                $ht = @{}
+                $expected = '@{}'
+
+                $result = Format-Hashtable -Hashtable $ht
+                $result | Should -Be $expected
+            }
+        }
+
         Context 'Simple Hashtable' {
             It 'formats a simple hashtable correctly' {
                 $ht = [ordered]@{


### PR DESCRIPTION
## Description

This pull request includes changes to the `Format-Hashtable` function and its corresponding tests to handle empty hashtables correctly. The most important changes are as follows:

Improvements to `Format-Hashtable` function:

* [`src/functions/public/Format-Hashtable.ps1`](diffhunk://#diff-7d90dfc5bc21b6d23ceed48105316975686cabff108964a18fa84407c1429f87R68-R72): Added a check to return '@{}' immediately if the hashtable is empty.

Enhancements to tests:

* [`tests/Hashtable.Tests.ps1`](diffhunk://#diff-0d9a4623edf86d4025f7602749bc2c1397bec49ddcbb1fa7b51fe34634049687R258-R267): Added a new test context to ensure that the `Format-Hashtable` function returns an empty hashtable string when given an empty hashtable.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
