### PR TITLE
🩹 [Patch]: Format `$null` values

### DIFF
--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -79,10 +79,13 @@
         Write-Verbose "Processing key: [$key]"
         $value = $Hashtable[$key]
         Write-Verbose "Processing value: [$value]"
-        Write-Verbose "Value type: [$($value.GetType().Name)]"
         if ($null -eq $value) {
+            Write-Verbose "Value type: `$null"
             $lines += "$levelIndent$key = `$null"
-        } elseif (($value -is [System.Collections.Hashtable]) -or ($value -is [System.Collections.Specialized.OrderedDictionary])) {
+            continue
+        }
+        Write-Verbose "Value type: [$($value.GetType().Name)]"
+        if (($value -is [System.Collections.Hashtable]) -or ($value -is [System.Collections.Specialized.OrderedDictionary])) {
             $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$key = $nestedString"
         } elseif ($value -is [System.Management.Automation.PSCustomObject]) {

--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -76,14 +76,10 @@
     $levelIndent = $indent * $IndentLevel
 
     foreach ($key in $Hashtable.Keys) {
-        Write-Verbose "Processing key: $key"
+        Write-Verbose "Processing key: [$key]"
         $value = $Hashtable[$key]
-        Write-Verbose "Processing value: $value"
-        if ($null -eq $value) {
-            Write-Verbose "Value type: `$null"
-            continue
-        }
-        Write-Verbose "Value type: $($value.GetType().Name)"
+        Write-Verbose "Processing value: [$value]"
+        Write-Verbose "Value type: [$($value.GetType().Name)]"
         if ($null -eq $value) {
             $lines += "$levelIndent$key = `$null"
         } elseif (($value -is [System.Collections.Hashtable]) -or ($value -is [System.Collections.Specialized.OrderedDictionary])) {

--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -84,7 +84,9 @@
             continue
         }
         Write-Verbose "Value type: $($value.GetType().Name)"
-        if (($value -is [System.Collections.Hashtable]) -or ($value -is [System.Collections.Specialized.OrderedDictionary])) {
+        if ($null -eq $value) {
+            $lines += "$levelIndent$key = `$null"
+        } elseif (($value -is [System.Collections.Hashtable]) -or ($value -is [System.Collections.Specialized.OrderedDictionary])) {
             $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$key = $nestedString"
         } elseif ($value -is [System.Management.Automation.PSCustomObject]) {

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -271,12 +271,14 @@
                     Key1 = 'Value1'
                     Key2 = 123
                     Key3 = @{}
+                    Key4 = $null
                 }
                 $expected = @'
 @{
     Key1 = 'Value1'
     Key2 = 123
     Key3 = @{}
+    Key4 = $null
 }
 '@.TrimEnd()
 
@@ -292,6 +294,8 @@
                     Key2 = [ordered]@{
                         NestedKey1 = 'NestedValue1'
                         NestedKey2 = 'NestedValue2'
+                        NestedKey3 = @{}
+                        NestedKey4 = $null
                     }
                 }
                 $expected = @'
@@ -300,6 +304,8 @@
     Key2 = @{
         NestedKey1 = 'NestedValue1'
         NestedKey2 = 'NestedValue2'
+        NestedKey3 = @{}
+        NestedKey4 = $null
     }
 }
 '@.TrimEnd()

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -296,6 +296,7 @@
                         NestedKey2 = 'NestedValue2'
                         NestedKey3 = @{}
                         NestedKey4 = $null
+                        NestedKey5 = ''
                     }
                 }
                 $expected = @'
@@ -306,6 +307,7 @@
         NestedKey2 = 'NestedValue2'
         NestedKey3 = @{}
         NestedKey4 = $null
+        NestedKey5 = ''
     }
 }
 '@.TrimEnd()
@@ -394,6 +396,7 @@
                         SubKey2 = @(
                             'ArrayInsideHashtable1'
                             'ArrayInsideHashtable2'
+                            ''
                             @{
                                 EvenDeeper = "Yes, it's deep!"
                             }
@@ -431,6 +434,7 @@
         SubKey2 = @(
             'ArrayInsideHashtable1'
             'ArrayInsideHashtable2'
+            ''
             @{
                 EvenDeeper = 'Yes, it''s deep!'
             }

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -413,6 +413,7 @@
     StringKey = 'Hello ''PowerShell''!'
     NumberKey = 42
     BooleanKey = $true
+    NullKey = $null
     ArrayKey = @(
         'FirstItem'
         123


### PR DESCRIPTION
## Description

This pull request includes changes to the `Format-Hashtable` function and its associated tests to handle `$null` values and empty strings within hashtables.

Changes to `Format-Hashtable` function:

* [`src/functions/public/Format-Hashtable.ps1`](diffhunk://#diff-7d90dfc5bc21b6d23ceed48105316975686cabff108964a18fa84407c1429f87L87-R89): Added a condition to check if the value is `$null` and format it accordingly.

Updates to test cases:

* [`tests/Hashtable.Tests.ps1`](diffhunk://#diff-0d9a4623edf86d4025f7602749bc2c1397bec49ddcbb1fa7b51fe34634049687R274-R281): Added test cases to verify the handling of `$null` values and empty strings in hashtables and nested dictionaries. [[1]](diffhunk://#diff-0d9a4623edf86d4025f7602749bc2c1397bec49ddcbb1fa7b51fe34634049687R274-R281) [[2]](diffhunk://#diff-0d9a4623edf86d4025f7602749bc2c1397bec49ddcbb1fa7b51fe34634049687R297-R299) [[3]](diffhunk://#diff-0d9a4623edf86d4025f7602749bc2c1397bec49ddcbb1fa7b51fe34634049687R308-R310) [[4]](diffhunk://#diff-0d9a4623edf86d4025f7602749bc2c1397bec49ddcbb1fa7b51fe34634049687R399) [[5]](diffhunk://#diff-0d9a4623edf86d4025f7602749bc2c1397bec49ddcbb1fa7b51fe34634049687R437)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
