### PR TITLE
🩹 [Patch]: Align `=` in `Format-Hashtable`

### DIFF
--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -410,11 +410,11 @@
                 # Assert - Define the expected output
                 $expectedOutput = @'
 @{
-    StringKey = 'Hello ''PowerShell''!'
-    NumberKey = 42
-    BooleanKey = $true
-    NullKey = $null
-    ArrayKey = @(
+    StringKey       = 'Hello ''PowerShell''!'
+    NumberKey       = 42
+    BooleanKey      = $true
+    NullKey         = $null
+    ArrayKey        = @(
         'FirstItem'
         123
         $false


### PR DESCRIPTION
## Description

This pull request includes changes to the `Format-Hashtable` function to improve the alignment of key-value pairs in the formatted output.

- Fixes #9

Improvements to key-value alignment:

* `Format-Hashtable`: Added a calculation for the maximum key length at the current level to align the `=` characters.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
