### PR TITLE
🩹 [Patch]: Update `Format-Hashtable` to handle objects

### DIFF
--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -56,15 +56,15 @@
             ValueFromPipeline,
             ValueFromPipelineByPropertyName
         )]
-        [object] $Hashtable,
+        [System.Collections.IDictionary] $Hashtable,
 
         # The indentation level for formatting nested structures.
         [Parameter()]
         [int] $IndentLevel = 1
     )
 
-    # If the hashtable is empty, return '@{}' immediately.
-    if ($Hashtable -is [System.Collections.IDictionary] -and $Hashtable.Count -eq 0) {
+    # If this is null, just return "@{}" to avoid errors
+    if ($Hashtable.Count -eq 0) {
         return '@{}'
     }
 
@@ -88,14 +88,14 @@
             continue
         }
         Write-Verbose "Value type: [$($value.GetType().Name)]"
-        if (($value -is [System.Collections.Hashtable]) -or ($value -is [System.Collections.Specialized.OrderedDictionary])) {
+        if (($value -is [System.Collections.IDictionary])) {
             $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [System.Management.Automation.PSCustomObject]) {
-            $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
+            $nestedString = $value | ConvertTo-Hashtable | Format-Hashtable -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [System.Management.Automation.PSObject]) {
-            $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
+            $nestedString = $value | ConvertTo-Hashtable | Format-Hashtable -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [bool]) {
             $lines += "$levelIndent$paddedKey = `$$($value.ToString().ToLower())"

--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -63,7 +63,7 @@
         [int] $IndentLevel = 1
     )
 
-    # If this is null, just return "@{}" to avoid errors
+    # If the hashtable is empty, return '@{}' immediately.
     if ($Hashtable.Count -eq 0) {
         return '@{}'
     }

--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -56,7 +56,7 @@
             ValueFromPipeline,
             ValueFromPipelineByPropertyName
         )]
-        [System.Collections.IDictionary] $Hashtable,
+        [object] $Hashtable,
 
         # The indentation level for formatting nested structures.
         [Parameter()]
@@ -64,7 +64,7 @@
     )
 
     # If the hashtable is empty, return '@{}' immediately.
-    if ($Hashtable.Count -eq 0) {
+    if ($Hashtable -is [System.Collections.IDictionary] -and $Hashtable.Count -eq 0) {
         return '@{}'
     }
 
@@ -88,14 +88,14 @@
             continue
         }
         Write-Verbose "Value type: [$($value.GetType().Name)]"
-        if (($value -is [System.Collections.IDictionary])) {
+        if (($value -is [System.Collections.Hashtable]) -or ($value -is [System.Collections.Specialized.OrderedDictionary])) {
             $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [System.Management.Automation.PSCustomObject]) {
-            $nestedString = $value | ConvertTo-Hashtable | Format-Hashtable -IndentLevel ($IndentLevel + 1)
+            $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [System.Management.Automation.PSObject]) {
-            $nestedString = $value | ConvertTo-Hashtable | Format-Hashtable -IndentLevel ($IndentLevel + 1)
+            $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [bool]) {
             $lines += "$levelIndent$paddedKey = `$$($value.ToString().ToLower())"

--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -56,7 +56,7 @@
             ValueFromPipeline,
             ValueFromPipelineByPropertyName
         )]
-        [object] $Hashtable,
+        [System.Collections.IDictionary] $Hashtable,
 
         # The indentation level for formatting nested structures.
         [Parameter()]
@@ -64,7 +64,7 @@
     )
 
     # If the hashtable is empty, return '@{}' immediately.
-    if ($Hashtable -is [System.Collections.IDictionary] -and $Hashtable.Count -eq 0) {
+    if ($Hashtable.Count -eq 0) {
         return '@{}'
     }
 
@@ -88,14 +88,14 @@
             continue
         }
         Write-Verbose "Value type: [$($value.GetType().Name)]"
-        if (($value -is [System.Collections.Hashtable]) -or ($value -is [System.Collections.Specialized.OrderedDictionary])) {
+        if (($value -is [System.Collections.IDictionary])) {
             $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [System.Management.Automation.PSCustomObject]) {
-            $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
+            $nestedString = $value | ConvertTo-Hashtable | Format-Hashtable -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [System.Management.Automation.PSObject]) {
-            $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
+            $nestedString = $value | ConvertTo-Hashtable | Format-Hashtable -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [bool]) {
             $lines += "$levelIndent$paddedKey = `$$($value.ToString().ToLower())"

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -401,12 +401,6 @@
                                 EvenDeeper = "Yes, it's deep!"
                             }
                         )
-                        Data    = [ordered]@{
-                            Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
-                            Data = [pscustomobject]@{
-                                Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
-                            }
-                        }
                     }
                     Run             = [ordered]@{
                         ABoolean            = $true
@@ -419,13 +413,13 @@
                         AnArrayOfHashtables = @(
                             [ordered]@{
                                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
-                                Data = @{
+                                Data = [pscustomobject]@{
                                     Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
                                 }
                             },
                             [ordered]@{
                                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Tests.ps1'
-                                Data = @{
+                                Data = [pscustomobject]@{
                                     Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Data.ps1'
                                 }
                             }
@@ -469,12 +463,6 @@
                 EvenDeeper = 'Yes, it''s deep!'
             }
         )
-        Data    = @{
-            Data = @{
-                Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
-            }
-            Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
-        }
     }
     Run             = @{
         ABoolean            = $true

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -401,6 +401,12 @@
                                 EvenDeeper = "Yes, it's deep!"
                             }
                         )
+                        Data    = [psscustomobject]@{
+                            Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
+                            Data = [psscustomobject]@{
+                                Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+                            }
+                        }
                     }
                     Run             = [ordered]@{
                         ABoolean            = $true

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -401,9 +401,9 @@
                                 EvenDeeper = "Yes, it's deep!"
                             }
                         )
-                        Data    = [psscustomobject]@{
+                        Data    = [pscustomobject]@{
                             Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
-                            Data = [psscustomobject]@{
+                            Data = [pscustomobject]@{
                                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
                             }
                         }

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -401,7 +401,7 @@
                                 EvenDeeper = "Yes, it's deep!"
                             }
                         )
-                        Data    = [pscustomobject]@{
+                        Data    = [ordered]@{
                             Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
                             Data = [pscustomobject]@{
                                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -208,7 +208,7 @@
     }
 
     Describe 'ConvertFrom-Hashtable' {
-        Context 'ConvertFrom-Hashtable - simple usage' {
+        Get-Context 'ConvertFrom-Hashtable - simple usage' {
             It 'ConvertFrom-Hashtable - converts a flat hashtable to PSCustomObject' {
                 $hashtable = @{ Name = 'John Doe'; Age = 30 }
                 $result = $hashtable | ConvertFrom-Hashtable
@@ -219,7 +219,7 @@
             }
         }
 
-        Context 'ConvertFrom-Hashtable - nested hashtable conversion' {
+        Get-Context 'ConvertFrom-Hashtable - nested hashtable conversion' {
             It 'ConvertFrom-Hashtable - correctly converts nested hashtables' {
                 $hashtable = @{ Address = @{ Street = '123 Main St'; City = 'Somewhere' } }
                 $result = $hashtable | ConvertFrom-Hashtable
@@ -231,7 +231,7 @@
             }
         }
 
-        Context 'ConvertFrom-Hashtable - array of hashtables' {
+        Get-Context 'ConvertFrom-Hashtable - array of hashtables' {
             It 'ConvertFrom-Hashtable - converts an array of hashtables to objects' {
                 $hashtable = @{ Employees = @(@{ Name = 'Alice' }, @{ Name = 'Bob' }) }
                 $result = $hashtable | ConvertFrom-Hashtable
@@ -244,7 +244,7 @@
             }
         }
 
-        Context 'ConvertFrom-Hashtable - empty hashtable' {
+        Get-Context 'ConvertFrom-Hashtable - empty hashtable' {
             It 'ConvertFrom-Hashtable - returns an empty PSCustomObject when input is empty' {
                 $result = @{} | ConvertFrom-Hashtable
 
@@ -255,7 +255,7 @@
     }
 
     Describe 'Format-Hashtable' {
-        Context 'An empty hashtable' {
+        Get-Context 'An empty hashtable' {
             It 'returns an empty hashtable string' {
                 $ht = @{}
                 $expected = '@{}'
@@ -265,7 +265,7 @@
             }
         }
 
-        Context 'Simple Hashtable' {
+        Get-Context 'Simple Hashtable' {
             It 'formats a simple hashtable correctly' {
                 $ht = [ordered]@{
                     Key1 = 'Value1'
@@ -287,7 +287,7 @@
             }
         }
 
-        Context 'Nested Hashtable' {
+        Get-Context 'Nested Hashtable' {
             It 'formats a nested hashtable correctly' {
                 $ht = [ordered]@{
                     Key1 = 'Value1'
@@ -317,7 +317,7 @@
             }
         }
 
-        Context 'Hashtable with Array' {
+        Get-Context 'Hashtable with Array' {
             It 'formats a hashtable containing an array correctly' {
                 $ht = @{
                     Key3 = @(1, 2, 3)
@@ -337,7 +337,7 @@
             }
         }
 
-        Context 'Hashtable with Boolean' {
+        Get-Context 'Hashtable with Boolean' {
             It 'formats boolean values correctly' {
                 $ht = @{
                     Key4 = $true
@@ -353,7 +353,7 @@
             }
         }
 
-        Context 'Escaping Single Quotes' {
+        Get-Context 'Escaping Single Quotes' {
             It 'escapes single quotes in string values' {
                 $ht = @{
                     Key5 = "O'Reilly"
@@ -370,7 +370,7 @@
             }
         }
 
-        Context 'A complex hashtable structure' {
+        Get-Context 'A complex hashtable structure' {
             It 'Should correctly format a complex nested hashtable' {
                 # Arrange - Define the complex test hashtable
                 $testHashtable = [ordered]@{
@@ -399,6 +399,29 @@
                             ''
                             @{
                                 EvenDeeper = "Yes, it's deep!"
+                            }
+                        )
+                    }
+                    Run             = @{
+                        ABoolean            = $true
+                        AString             = 'Hello'
+                        AnArray             = @('One', 'Two', 'Three')
+                        AnObject            = @{
+                            NestedKey1 = 'NestedValue1'
+                            NestedKey2 = 'NestedValue2'
+                        }
+                        AnArrayOfHashtables = @(
+                            @{
+                                Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
+                                Data = @{
+                                    Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+                                }
+                            },
+                            @{
+                                Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Tests.ps1'
+                                Data = @{
+                                    Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Data.ps1'
+                                }
                             }
                         )
                     }
@@ -441,6 +464,29 @@
             }
         )
     }
+    Run             = @{
+        AString             = 'Hello'
+        AnArray             = @(
+            'One'
+            'Two'
+            'Three'
+        )
+        AnObject            = @{
+            NestedKey1 = 'NestedValue1'
+            NestedKey2 = 'NestedValue2'
+        }
+        ABoolean            = $true
+        AnArrayOfHashtables = @(
+            @{
+                Key2 = 'Value2'
+                Key1 = 'Value1'
+            }
+            @{
+                Key4 = 'Value4'
+                Key3 = 'Value3'
+            }
+        )
+    }
 }
 '@.Trim() # Trim to remove any unintended whitespace
 
@@ -451,7 +497,7 @@
     }
 
     Describe 'Remove-HashtableEntry' {
-        Context 'Remove-HashtableEntry - NullOrEmptyValues' {
+        Get-Context 'Remove-HashtableEntry - NullOrEmptyValues' {
             It 'Removes keys with null or empty values' {
                 $Hashtable = @{
                     'Key1' = 'Value1'
@@ -468,7 +514,7 @@
             }
         }
 
-        Context 'Remove-HashtableEntry - RemoveTypes' {
+        Get-Context 'Remove-HashtableEntry - RemoveTypes' {
             It 'Removes keys with specified value types' {
                 $Hashtable = @{
                     'Key1' = 'Value1'
@@ -485,7 +531,7 @@
             }
         }
 
-        Context 'Remove-HashtableEntry - RemoveNames' {
+        Get-Context 'Remove-HashtableEntry - RemoveNames' {
             It 'Removes specific keys by name' {
                 $Hashtable = @{
                     'KeepThis'   = 'Value'
@@ -498,7 +544,7 @@
             }
         }
 
-        Context 'Remove-HashtableEntry - KeepTypes' {
+        Get-Context 'Remove-HashtableEntry - KeepTypes' {
             It 'Removes keys not of specified types' {
                 $Hashtable = @{
                     'Key1' = 'Value1'
@@ -515,7 +561,7 @@
             }
         }
 
-        Context 'Remove-HashtableEntry - KeepNames' {
+        Get-Context 'Remove-HashtableEntry - KeepNames' {
             It 'Removes keys not matching specified names' {
                 $Hashtable = @{
                     'KeepThis'   = 'Value'

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -469,6 +469,12 @@
                 EvenDeeper = 'Yes, it''s deep!'
             }
         )
+        Data    = @{
+            Data = @{
+                Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+            }
+            Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
+        }
     }
     Run             = @{
         ABoolean            = $true

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -208,7 +208,7 @@
     }
 
     Describe 'ConvertFrom-Hashtable' {
-        Get-Context 'ConvertFrom-Hashtable - simple usage' {
+        Context 'ConvertFrom-Hashtable - simple usage' {
             It 'ConvertFrom-Hashtable - converts a flat hashtable to PSCustomObject' {
                 $hashtable = @{ Name = 'John Doe'; Age = 30 }
                 $result = $hashtable | ConvertFrom-Hashtable
@@ -219,7 +219,7 @@
             }
         }
 
-        Get-Context 'ConvertFrom-Hashtable - nested hashtable conversion' {
+        Context 'ConvertFrom-Hashtable - nested hashtable conversion' {
             It 'ConvertFrom-Hashtable - correctly converts nested hashtables' {
                 $hashtable = @{ Address = @{ Street = '123 Main St'; City = 'Somewhere' } }
                 $result = $hashtable | ConvertFrom-Hashtable
@@ -231,7 +231,7 @@
             }
         }
 
-        Get-Context 'ConvertFrom-Hashtable - array of hashtables' {
+        Context 'ConvertFrom-Hashtable - array of hashtables' {
             It 'ConvertFrom-Hashtable - converts an array of hashtables to objects' {
                 $hashtable = @{ Employees = @(@{ Name = 'Alice' }, @{ Name = 'Bob' }) }
                 $result = $hashtable | ConvertFrom-Hashtable
@@ -244,7 +244,7 @@
             }
         }
 
-        Get-Context 'ConvertFrom-Hashtable - empty hashtable' {
+        Context 'ConvertFrom-Hashtable - empty hashtable' {
             It 'ConvertFrom-Hashtable - returns an empty PSCustomObject when input is empty' {
                 $result = @{} | ConvertFrom-Hashtable
 
@@ -255,7 +255,7 @@
     }
 
     Describe 'Format-Hashtable' {
-        Get-Context 'An empty hashtable' {
+        Context 'An empty hashtable' {
             It 'returns an empty hashtable string' {
                 $ht = @{}
                 $expected = '@{}'
@@ -265,7 +265,7 @@
             }
         }
 
-        Get-Context 'Simple Hashtable' {
+        Context 'Simple Hashtable' {
             It 'formats a simple hashtable correctly' {
                 $ht = [ordered]@{
                     Key1 = 'Value1'
@@ -287,7 +287,7 @@
             }
         }
 
-        Get-Context 'Nested Hashtable' {
+        Context 'Nested Hashtable' {
             It 'formats a nested hashtable correctly' {
                 $ht = [ordered]@{
                     Key1 = 'Value1'
@@ -317,7 +317,7 @@
             }
         }
 
-        Get-Context 'Hashtable with Array' {
+        Context 'Hashtable with Array' {
             It 'formats a hashtable containing an array correctly' {
                 $ht = @{
                     Key3 = @(1, 2, 3)
@@ -337,7 +337,7 @@
             }
         }
 
-        Get-Context 'Hashtable with Boolean' {
+        Context 'Hashtable with Boolean' {
             It 'formats boolean values correctly' {
                 $ht = @{
                     Key4 = $true
@@ -353,7 +353,7 @@
             }
         }
 
-        Get-Context 'Escaping Single Quotes' {
+        Context 'Escaping Single Quotes' {
             It 'escapes single quotes in string values' {
                 $ht = @{
                     Key5 = "O'Reilly"
@@ -370,7 +370,7 @@
             }
         }
 
-        Get-Context 'A complex hashtable structure' {
+        Context 'A complex hashtable structure' {
             It 'Should correctly format a complex nested hashtable' {
                 # Arrange - Define the complex test hashtable
                 $testHashtable = [ordered]@{
@@ -497,7 +497,7 @@
     }
 
     Describe 'Remove-HashtableEntry' {
-        Get-Context 'Remove-HashtableEntry - NullOrEmptyValues' {
+        Context 'Remove-HashtableEntry - NullOrEmptyValues' {
             It 'Removes keys with null or empty values' {
                 $Hashtable = @{
                     'Key1' = 'Value1'
@@ -514,7 +514,7 @@
             }
         }
 
-        Get-Context 'Remove-HashtableEntry - RemoveTypes' {
+        Context 'Remove-HashtableEntry - RemoveTypes' {
             It 'Removes keys with specified value types' {
                 $Hashtable = @{
                     'Key1' = 'Value1'
@@ -531,7 +531,7 @@
             }
         }
 
-        Get-Context 'Remove-HashtableEntry - RemoveNames' {
+        Context 'Remove-HashtableEntry - RemoveNames' {
             It 'Removes specific keys by name' {
                 $Hashtable = @{
                     'KeepThis'   = 'Value'
@@ -544,7 +544,7 @@
             }
         }
 
-        Get-Context 'Remove-HashtableEntry - KeepTypes' {
+        Context 'Remove-HashtableEntry - KeepTypes' {
             It 'Removes keys not of specified types' {
                 $Hashtable = @{
                     'Key1' = 'Value1'
@@ -561,7 +561,7 @@
             }
         }
 
-        Get-Context 'Remove-HashtableEntry - KeepNames' {
+        Context 'Remove-HashtableEntry - KeepNames' {
             It 'Removes keys not matching specified names' {
                 $Hashtable = @{
                     'KeepThis'   = 'Value'

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -402,22 +402,22 @@
                             }
                         )
                     }
-                    Run             = @{
+                    Run             = [ordered]@{
                         ABoolean            = $true
                         AString             = 'Hello'
                         AnArray             = @('One', 'Two', 'Three')
-                        AnObject            = @{
+                        AnObject            = [ordered]@{
                             NestedKey1 = 'NestedValue1'
                             NestedKey2 = 'NestedValue2'
                         }
                         AnArrayOfHashtables = @(
-                            @{
+                            [ordered]@{
                                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
                                 Data = @{
                                     Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
                                 }
                             },
-                            @{
+                            [ordered]@{
                                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Tests.ps1'
                                 Data = @{
                                     Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Data.ps1'
@@ -465,6 +465,7 @@
         )
     }
     Run             = @{
+        ABoolean            = $true
         AString             = 'Hello'
         AnArray             = @(
             'One'
@@ -475,19 +476,23 @@
             NestedKey1 = 'NestedValue1'
             NestedKey2 = 'NestedValue2'
         }
-        ABoolean            = $true
         AnArrayOfHashtables = @(
             @{
-                Key2 = 'Value2'
-                Key1 = 'Value1'
+                Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
+                Data = @{
+                    Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+                }
             }
             @{
-                Key4 = 'Value4'
-                Key3 = 'Value3'
+                Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Tests.ps1'
+                Data = @{
+                    Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Data.ps1'
+                }
             }
         )
     }
 }
+
 '@.Trim() # Trim to remove any unintended whitespace
 
                 # Compare function output to expected output


### PR DESCRIPTION
## Description

This pull request includes updates to the `Format-Hashtable` function to improve type handling and formatting, as well as adding corresponding tests in `Hashtable.Tests.ps1`.

### Improvements to `Format-Hashtable`:

* Changed the parameter type for `Hashtable` to `System.Collections.IDictionary` to ensure compatibility with different dictionary types.
* Simplified the check for an empty hashtable by removing the redundant type check.
* Unified the condition for nested hashtable formatting to use `System.Collections.IDictionary` for consistency.
* Updated the handling of `PSCustomObject` and `PSObject` values to use `ConvertTo-Hashtable` for proper conversion before formatting.

### Enhancements to `Hashtable.Tests.ps1`:

* Added comprehensive test cases to cover various scenarios including nested objects and arrays of hashtables.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
