### PR TITLE
🩹 [Patch]: Ensure all other value types is converted to string in `Format-Hashtable`

### DIFF
--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -128,7 +128,7 @@
             }
         } else {
             $value = $value -replace "('+)", "''" # Escape single quotes in a manifest file
-            $lines += "$levelIndent$paddedKey = '$value'"
+            $lines += "$levelIndent$paddedKey = '$($value.ToString())'"
         }
     }
     $levelIndent = $indent * ($IndentLevel - 1)

--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -114,7 +114,12 @@
                     Write-Verbose "Element type: [$($nestedValue.GetType().Name)]"
 
                     if (($nestedValue -is [System.Collections.IDictionary])) {
+                        # Nested hashtable
                         $nestedString = Format-Hashtable -Hashtable $nestedValue -IndentLevel ($IndentLevel + 2)
+                        $lines += "$arrayIndent$nestedString"
+                    } elseif ($nestedValue -is [System.Management.Automation.PSCustomObject]) {
+                        # PSCustomObject => Convert to hashtable & recurse
+                        $nestedString = $nestedValue | ConvertTo-Hashtable | Format-Hashtable -IndentLevel ($IndentLevel + 2)
                         $lines += "$arrayIndent$nestedString"
                     } elseif ( $nestedValue -is [bool] -or $nestedValue -is [System.Management.Automation.SwitchParameter] ) {
                         $boolValue = [bool]$nestedValue

--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -99,7 +99,7 @@
         } elseif ( $value -is [bool] -or $value -is [System.Management.Automation.SwitchParameter] ) {
             $boolValue = [bool]$value
             $lines += "$levelIndent$paddedKey = `$$($boolValue.ToString().ToLower())"
-        } elseif ([System.Management.Automation.LanguagePrimitives]::IsNumeric($value.GetType())) {
+        } elseif ($value -is [int] -or $value -is [long] -or $value -is [double] -or $value -is [decimal]) {
             $lines += "$levelIndent$paddedKey = $value"
         } elseif ($value -is [System.Collections.IList]) {
             # This covers normal arrays, ArrayList, List<T>, etc.
@@ -119,7 +119,7 @@
                     } elseif ( $nestedValue -is [bool] -or $nestedValue -is [System.Management.Automation.SwitchParameter] ) {
                         $boolValue = [bool]$nestedValue
                         $lines += "$arrayIndent`$$($boolValue.ToString().ToLower())"
-                    } elseif ([System.Management.Automation.LanguagePrimitives]::IsNumeric($value.GetType())) {
+                    } elseif ($nestedValue -is [int] -or $nestedValue -is [long] -or $nestedValue -is [double] -or $nestedValue -is [decimal]) {
                         $lines += "$arrayIndent$nestedValue"
                     } else {
                         # Fallback => treat as string (escape single-quotes)

--- a/src/functions/public/Format-Hashtable.ps1
+++ b/src/functions/public/Format-Hashtable.ps1
@@ -88,50 +88,57 @@
             continue
         }
         Write-Verbose "Value type: [$($value.GetType().Name)]"
-        if (($value -is [System.Collections.IDictionary])) {
+        if ($value -is [System.Collections.IDictionary]) {
+            # Nested hashtable
             $nestedString = Format-Hashtable -Hashtable $value -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
         } elseif ($value -is [System.Management.Automation.PSCustomObject]) {
+            # PSCustomObject => Convert to hashtable & recurse
             $nestedString = $value | ConvertTo-Hashtable | Format-Hashtable -IndentLevel ($IndentLevel + 1)
             $lines += "$levelIndent$paddedKey = $nestedString"
-        } elseif ($value -is [System.Management.Automation.PSObject]) {
-            $nestedString = $value | ConvertTo-Hashtable | Format-Hashtable -IndentLevel ($IndentLevel + 1)
-            $lines += "$levelIndent$paddedKey = $nestedString"
-        } elseif ($value -is [bool]) {
-            $lines += "$levelIndent$paddedKey = `$$($value.ToString().ToLower())"
-        } elseif ($value -is [int] -or $value -is [double]) {
+        } elseif ( $value -is [bool] -or $value -is [System.Management.Automation.SwitchParameter] ) {
+            $boolValue = [bool]$value
+            $lines += "$levelIndent$paddedKey = `$$($boolValue.ToString().ToLower())"
+        } elseif ([System.Management.Automation.LanguagePrimitives]::IsNumeric($value.GetType())) {
             $lines += "$levelIndent$paddedKey = $value"
-        } elseif ($value -is [array]) {
+        } elseif ($value -is [System.Collections.IList]) {
+            # This covers normal arrays, ArrayList, List<T>, etc.
             if ($value.Count -eq 0) {
                 $lines += "$levelIndent$paddedKey = @()"
             } else {
                 $lines += "$levelIndent$paddedKey = @("
-                $arrayIndent = $levelIndent + $indent  # Increase indentation for elements inside @(...)
+                $arrayIndent = $levelIndent + $indent
 
-                $value | ForEach-Object {
-                    $nestedValue = $_
-                    Write-Verbose "Processing array element: $_"
-                    Write-Verbose "Element type: $($_.GetType().Name)"
-                    if (($nestedValue -is [System.Collections.Hashtable]) -or ($nestedValue -is [System.Collections.Specialized.OrderedDictionary])) {
+                foreach ($nestedValue in $value) {
+                    Write-Verbose "Processing array element: [$nestedValue]"
+                    Write-Verbose "Element type: [$($nestedValue.GetType().Name)]"
+
+                    if (($nestedValue -is [System.Collections.IDictionary])) {
                         $nestedString = Format-Hashtable -Hashtable $nestedValue -IndentLevel ($IndentLevel + 2)
                         $lines += "$arrayIndent$nestedString"
-                    } elseif ($nestedValue -is [bool]) {
-                        $lines += "$arrayIndent`$$($nestedValue.ToString().ToLower())"
-                    } elseif ($nestedValue -is [int]) {
+                    } elseif ( $nestedValue -is [bool] -or $nestedValue -is [System.Management.Automation.SwitchParameter] ) {
+                        $boolValue = [bool]$nestedValue
+                        $lines += "$arrayIndent`$$($boolValue.ToString().ToLower())"
+                    } elseif ([System.Management.Automation.LanguagePrimitives]::IsNumeric($value.GetType())) {
                         $lines += "$arrayIndent$nestedValue"
                     } else {
-                        $lines += "$arrayIndent'$nestedValue'"
+                        # Fallback => treat as string (escape single-quotes)
+                        $escapedElement = $nestedValue -replace "('+)", "''"
+                        $lines += "$arrayIndent'$escapedElement'"
                     }
                 }
-                $arrayIndent = $levelIndent
-                $lines += "$arrayIndent)"
+
+                $lines += ($levelIndent + ')')
             }
         } else {
-            $value = $value -replace "('+)", "''" # Escape single quotes in a manifest file
-            $lines += "$levelIndent$paddedKey = '$($value.ToString())'"
+            # Fallback: treat as string (escaping single-quotes)
+            $escapedValue = $value -replace "('+)", "''"
+            $lines += "$levelIndent$paddedKey = '$escapedValue'"
         }
     }
+
     $levelIndent = $indent * ($IndentLevel - 1)
     $lines += "$levelIndent}"
+
     return $lines -join [Environment]::NewLine
 }

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -437,7 +437,7 @@
 
                 # Act - Run the function
                 $formatted = Format-Hashtable -Hashtable $testHashtable
-
+                Write-Verbose $formatted -Verbose
                 # Assert - Define the expected output
                 $expectedOutput = @'
 @{
@@ -510,6 +510,7 @@
 }
 
 '@.Trim() # Trim to remove any unintended whitespace
+                Write-Verbose $expectedOutput -Verbose
 
                 # Compare function output to expected output
                 $formatted | Should -BeExactly $expectedOutput

--- a/tests/Hashtable.Tests.ps1
+++ b/tests/Hashtable.Tests.ps1
@@ -413,9 +413,17 @@
                         AnArrayOfHashtables = @(
                             [ordered]@{
                                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
-                                Data = [pscustomobject]@{
-                                    Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
-                                }
+                                Data = @(
+                                    [pscustomobject]@{
+                                        Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+                                    },
+                                    [pscustomobject]@{
+                                        Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+                                    },
+                                    [pscustomobject]@{
+                                        Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+                                    }
+                                )
                             },
                             [ordered]@{
                                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Tests.ps1'
@@ -479,9 +487,17 @@
         AnArrayOfHashtables = @(
             @{
                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Tests.ps1'
-                Data = @{
-                    Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
-                }
+                Data = @(
+                    @{
+                        Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+                    }
+                    @{
+                        Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+                    }
+                    @{
+                        Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Planets\Planets.Data.ps1'
+                    }
+                )
             }
             @{
                 Path = 'C:\Repos\GitHub\PSModule\Action\Invoke-Pester\tests\3-Advanced\Sheep\Sheep.Tests.ps1'


### PR DESCRIPTION
## Description

This pull request includes several key improvements and bug fixes to the `Format-Hashtable` function. 

Enhancements to data type handling:

* Improved handling of `PSCustomObject` by converting it to a hashtable and recursively formatting it.
* Added support for `SwitchParameter` type alongside `bool`, ensuring proper conversion and formatting.
* Enhanced handling of numeric types by including `long` and `decimal` in addition to `int` and `double`.
* Refined array handling to support any `IList` implementation, covering normal arrays, `ArrayList`, `List<T>`, etc.

Code readability improvements:

* Added comments to explain the purpose of specific code blocks, such as nested hashtable handling and fallback string escaping.
* Streamlined `foreach` loop for array elements, improving verbosity and element processing.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
