### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Hashtable
 
-Hashtable is a PowerShell module that simplifies common hashtable operations.
+Hashtable is a comprehensive PowerShell module for working with hashtables. It converts hashtables to and from
+PSCustomObjects, formats hashtables into readable PowerShell code, merges hashtables with override support, and removes
+entries based on specific criteria — simplifying complex hashtable manipulations in your automation workflows.
 
 ## Installation
 
@@ -11,7 +13,81 @@ Install-PSResource -Name Hashtable
 Import-Module -Name Hashtable
 ```
 
-If your environment still uses PowerShellGet, install the module with `Install-Module -Name Hashtable` instead.
+## Usage
+
+### Example: Convert a hashtable to a PSCustomObject
+
+Convert a nested hashtable into a PSCustomObject, making it easier to manipulate and explore your data.
+
+```powershell
+$hashtable = @{
+    Name    = 'Alice'
+    Age     = 30
+    Contact = @{
+        Email = 'alice@example.com'
+        Phone = '123-456-7890'
+    }
+}
+
+$object = $hashtable | ConvertFrom-Hashtable
+$object | Format-List
+```
+
+### Example: Merge hashtables with overrides
+
+Merge a default settings hashtable with user-specified overrides. Values in the override hashtable replace those in the
+base hashtable.
+
+```powershell
+$defaultSettings = @{
+    Theme    = 'Light'
+    Language = 'en'
+    Layout   = 'Standard'
+}
+$userSettings = @{
+    Theme  = 'Dark'
+    Layout = 'Compact'
+}
+
+$mergedSettings = $defaultSettings | Merge-Hashtable -Overrides $userSettings
+$mergedSettings
+```
+
+### Example: Format a hashtable as PowerShell code
+
+Convert a hashtable into a nicely formatted PowerShell code representation — useful for exporting configuration to a
+`.psd1` file.
+
+```powershell
+$configuration = @{
+    Server      = 'localhost'
+    Port        = 8080
+    Credentials = @{
+        Username = 'admin'
+        Password = 'P@ssw0rd'
+    }
+    Enabled     = $true
+}
+
+$formattedConfig = $configuration | Format-Hashtable
+Write-Output $formattedConfig
+```
+
+### Example: Remove hashtable entries by criteria
+
+Remove specific entries from a hashtable, such as keys with null or empty values or a key matching a particular name.
+
+```powershell
+$ht = @{
+    ValidKey = 'SomeValue'
+    EmptyKey = ''
+    RemoveMe = 'Unwanted'
+}
+
+# Remove entries with null or empty values and the key named 'RemoveMe'
+$ht | Remove-HashtableEntry -NullOrEmptyValues -Keys 'RemoveMe'
+$ht
+```
 
 ## Documentation
 
@@ -21,9 +97,5 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Hashtable
-Get-Help ConvertTo-Hashtable -Examples
+Get-Help -Name ConvertTo-Hashtable -Examples
 ```
-
-## Contributing
-
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Hashtable
-Get-Help 'CommandName' -Examples
+Get-Help ConvertTo-HashTable -Examples
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Install-PSResource -Name Hashtable
 Import-Module -Name Hashtable
 ```
 
+If your environment still uses PowerShellGet, install the module with `Install-Module -Name Hashtable` instead.
+
 ## Documentation
 
 Documentation is published at [psmodule.io/Hashtable](https://psmodule.io/Hashtable/).
@@ -19,7 +21,7 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Hashtable
-Get-Help <CommandName> -Examples
+Get-Help 'CommandName' -Examples
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module Hashtable
-Get-Help ConvertTo-HashTable -Examples
+Get-Help ConvertTo-Hashtable -Examples
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,119 +1,27 @@
 # Hashtable
 
-Hashtable is a comprehensive module that provides functions for working with PowerShell hashtables.
-It enables you to convert hashtables to PSCustomObjects and vice versa, format hashtables into readable PowerShell
-code, merge hashtables with override support, and remove entries based on specific criteria. This collection of
-utilities is designed to simplify complex hashtable manipulations and help automate your PowerShell workflows.
-
-## Prerequisites
-
-This module uses the following external resources:
-- The [PSModule framework](https://github.com/PSModule) for building, testing, and publishing the module.
+Hashtable is a PowerShell module that simplifies common hashtable operations.
 
 ## Installation
 
-To install the module from the PowerShell Gallery, you can use the following command:
+Install the module from the PowerShell Gallery:
 
 ```powershell
 Install-PSResource -Name Hashtable
 Import-Module -Name Hashtable
 ```
 
-## Usage
-
-Below are some examples illustrating typical use cases for the module.
-
-### Example 1: Converting a Hashtable to a PSCustomObject
-
-This example demonstrates how to convert a nested hashtable into a PSCustomObject, making it easier to manipulate and explore your data.
-
-```powershell
-$hashtable = @{
-    Name    = 'Alice'
-    Age     = 30
-    Contact = @{
-        Email = 'alice@example.com'
-        Phone = '123-456-7890'
-    }
-}
-
-$object = $hashtable | ConvertFrom-Hashtable
-$object | Format-List
-```
-
-### Example 2: Merging Hashtables
-
-Merge a default settings hashtable with user-specified overrides. In this example, the values in the override hashtable
-replace those in the main hashtable.
-
-```powershell
-$defaultSettings = @{
-    Theme    = 'Light'
-    Language = 'en'
-    Layout   = 'Standard'
-}
-$userSettings = @{
-    Theme  = 'Dark'
-    Layout = 'Compact'
-}
-
-$mergedSettings = $defaultSettings | Merge-Hashtable -Overrides $userSettings
-$mergedSettings
-```
-
-### Example 3: Formatting a Hashtable as PowerShell Code
-
-Convert a hashtable into a nicely formatted PowerShell code representation. This is especially useful for exporting
-configurations to a `.psd1` file.
-
-```powershell
-$configuration = @{
-    Server      = 'localhost'
-    Port        = 8080
-    Credentials = @{
-        Username = 'admin'
-        Password = 'P@ssw0rd'
-    }
-    Enabled     = $true
-}
-
-$formattedConfig = $configuration | Format-Hashtable
-Write-Output $formattedConfig
-```
-
-### Example 4: Removing Hashtable Entries Based on Criteria
-
-Remove specific entries from a hashtable, such as keys with null or empty values, or those matching a particular name.
-
-```powershell
-$ht = @{
-    ValidKey  = 'SomeValue'
-    EmptyKey  = ''
-    RemoveMe  = 'Unwanted'
-}
-
-# Remove entries with null or empty values and keys named 'RemoveMe'
-$ht | Remove-HashtableEntry -NullOrEmptyValues -Keys 'RemoveMe'
-$ht
-```
-
-You can use `Get-Command -Module 'Hashtable'` to list available commands, and `Get-Help -Examples <CommandName>` to view command-specific examples.
-
 ## Documentation
 
-Detailed documentation for each function is available via inline help. For more extensive documentation, please visit the
-[Hashtable docs](https://psmodule.io/Hashtable/) or [PSModule Docs](https://psmodule.io/docs).
+Documentation is published at [psmodule.io/Hashtable](https://psmodule.io/Hashtable/).
+
+Use PowerShell help and command discovery for module details:
+
+```powershell
+Get-Command -Module Hashtable
+Get-Help <CommandName> -Examples
+```
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, your feedback is invaluable. If you encounter issues, unexpected behaviors, or missing functionality,
-please submit a bug report or feature request via the project's issues page.
-
-### For Developers
-
-If you code, we'd love to see your contributions. Please review the [Contribution Guidelines](CONTRIBUTING.md) for more details.
-You can start by picking up an existing issue or submitting a new one if you have an idea for a new feature or improvement.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.


### PR DESCRIPTION
## 📖 Docs: standard module landing-page README

The `Hashtable` README is now a proper landing page so users can get productive fast: a clear one-paragraph
overview, a copy-paste **Installation** block using `Install-PSResource`, a **Usage** showcase with real,
runnable examples, and a **Documentation** pointer to [psmodule.io/Hashtable](https://psmodule.io/Hashtable/).

### What changed

- Added a **`## Usage`** section with realistic examples using the real exported commands:
  - Convert a hashtable to a `PSCustomObject` (`ConvertFrom-Hashtable`)
  - Merge hashtables with overrides (`Merge-Hashtable`)
  - Format a hashtable as PowerShell code (`Format-Hashtable`)
  - Remove entries by criteria (`Remove-HashtableEntry`)
- **Documentation** discovery snippet uses a real command (`Get-Help -Name ConvertTo-Hashtable -Examples`).
- Removed the **`## Contributing`** section (community/contribution guidance lives outside the published
  landing page).
- Installation continues to use `Install-PSResource` / `Import-Module`.

Only `README.md` changed.
